### PR TITLE
feat: 전화번호 서식, 인증 재전송, UI 개선

### DIFF
--- a/src/components/auth/AuthInput.jsx
+++ b/src/components/auth/AuthInput.jsx
@@ -9,6 +9,7 @@ const InputContainer = styled.div`
     align-items: center;
     padding: 0 24px;
     box-sizing: border-box;
+    border: ${({ $borderColor }) => $borderColor || "none"};
 `;
 
 const StyledInput = styled.input`
@@ -29,8 +30,11 @@ const StyledInput = styled.input`
     }
 `;
 
-const AuthInput = ({ width, ...props }) => (
-    <InputContainer width={width}>
+const AuthInput = ({ width, borderColor, ...props }) => (
+    <InputContainer
+        width={width}
+        $borderColor={borderColor}
+    >
         <StyledInput {...props} />
     </InputContainer>
 );

--- a/src/components/auth/PhoneAuthForm.jsx
+++ b/src/components/auth/PhoneAuthForm.jsx
@@ -89,9 +89,7 @@ const PhoneAuthForm = () => {
                 },
             });
         } catch (error) {
-            setCodeError(
-                "인증 실패: " + (error.message || "")
-            );
+            setCodeError(error.message || "");
         } finally {
             setLoading(false);
         }
@@ -134,7 +132,7 @@ const PhoneAuthForm = () => {
                             width="129px"
                         >
                             {loading
-                                ? "전송 중..."
+                                ? "인증번호 재전송"
                                 : isCodeSent
                                 ? "인증번호 재전송"
                                 : "인증번호 전송"}

--- a/src/components/auth/PhoneAuthForm.jsx
+++ b/src/components/auth/PhoneAuthForm.jsx
@@ -9,6 +9,10 @@ import {
 import AuthInput from "./AuthInput";
 import AuthButton from "./AuthButton";
 import styled from "styled-components";
+import {
+    formatPhoneNumber,
+    formatPhoneNumberToE164,
+} from "../../utils/phoneUtils";
 
 const PhoneAuthForm = () => {
     const location = useLocation();
@@ -36,11 +40,15 @@ const PhoneAuthForm = () => {
     // 인증번호 전송
     const handleSendCode = async (e) => {
         e.preventDefault();
+        // 1. 현재 화면에 표시된 phoneNumber 상태를 E.164 형식으로 변환 시도
+        const formattedE164 =
+            formatPhoneNumberToE164(phoneNumber);
 
-        const formatted = phoneNumber.replace(/[-\s]/g, "");
-        if (!isValidPhoneNumber(formatted)) {
+        // 2. 변환된 E.164 형식이 유효한지 검사
+        if (!isValidPhoneNumber(formattedE164)) {
+            // 사용자에게는 익숙한 형식으로 안내하는 것이 더 좋을 수 있습니다.
             return alert(
-                "국가코드(+82)와 함께 올바른 전화번호를 입력하세요. 예: +821012345678"
+                "올바른 형식의 휴대폰 번호를 입력하세요."
             );
         }
 
@@ -48,7 +56,7 @@ const PhoneAuthForm = () => {
         try {
             // reCAPTCHA 확인은 sendPhoneVerification 내부에서 처리됨
             const vId = await sendPhoneVerification(
-                formatted
+                formattedE164
             );
             setVerificationId(vId);
             alert("인증번호가 전송되었습니다.");
@@ -95,14 +103,17 @@ const PhoneAuthForm = () => {
                         <AuthInput
                             width="283px"
                             name="phoneNumber"
-                            type="text"
-                            placeholder="전화번호(11자리)"
+                            type="tel"
+                            placeholder="010-1234-5678"
                             value={phoneNumber}
                             onChange={(e) =>
                                 setPhoneNumber(
-                                    e.target.value
+                                    formatPhoneNumber(
+                                        e.target.value
+                                    )
                                 )
                             }
+                            maxLength={13}
                             required
                             disabled={loading}
                         />

--- a/src/components/auth/PhoneAuthForm.jsx
+++ b/src/components/auth/PhoneAuthForm.jsx
@@ -23,6 +23,7 @@ const PhoneAuthForm = () => {
     const [phoneNumber, setPhoneNumber] = useState("");
     const [verificationCode, setVerificationCode] =
         useState("");
+    const [isCodeSent, setIsCodeSent] = useState(false); // 코드 전송 여부 상태만 유지
 
     // reCAPTCHA 초기화 - 이제 recaptchaVerified 상태가 필요 없음
     useEffect(() => {
@@ -59,6 +60,7 @@ const PhoneAuthForm = () => {
                 formattedE164
             );
             setVerificationId(vId);
+            setIsCodeSent(true); // 코드 전송 성공 상태로 변경
             alert("인증번호가 전송되었습니다.");
         } catch (error) {
             clearRecaptcha();
@@ -115,7 +117,7 @@ const PhoneAuthForm = () => {
                             }
                             maxLength={13}
                             required
-                            disabled={loading}
+                            disabled={isCodeSent}
                         />
                         <AuthButton
                             type="button"
@@ -126,6 +128,8 @@ const PhoneAuthForm = () => {
                         >
                             {loading
                                 ? "전송 중..."
+                                : isCodeSent // 코드가 한 번이라도 보내졌다면
+                                ? "인증번호 재전송" // 재전송 텍스트 표시
                                 : "인증번호 전송"}
                         </AuthButton>
                     </Row>
@@ -156,7 +160,7 @@ const PhoneAuthForm = () => {
                     onClick={handleVerifyCode}
                     disabled={loading || !verificationId}
                 >
-                    {loading ? "확인 중..." : "인증 확인"}
+                    인증 확인
                 </AuthButton>
             </div>
         </div>

--- a/src/components/auth/SignUpStep1.jsx
+++ b/src/components/auth/SignUpStep1.jsx
@@ -2,6 +2,7 @@ import AuthInput from "./AuthInput";
 import AuthButton from "./AuthButton";
 import GenderSelector from "./GenderSelector";
 import styled from "styled-components";
+import { formatPhoneNumber } from "../../utils/phoneUtils";
 
 const SignUpStep1 = ({
     name,
@@ -45,10 +46,15 @@ const SignUpStep1 = ({
                 </Row>
                 <AuthInput
                     type="tel"
+                    maxLength={13}
                     placeholder="010-1234-5678"
                     value={phone}
                     onChange={(e) =>
-                        setPhone(e.target.value)
+                        setPhone(
+                            formatPhoneNumber(
+                                e.target.value
+                            )
+                        )
                     }
                 />
 

--- a/src/utils/phoneUtils.js
+++ b/src/utils/phoneUtils.js
@@ -1,0 +1,49 @@
+// 입력된 문자열을 한국 휴대폰 번호 형식(XXX-XXXX-XXXX)으로 변환합니다.
+export const formatPhoneNumber = (value) => {
+    // 입력값이 없거나 유효하지 않으면 빈 문자열 반환
+    if (!value) {
+        return "";
+    }
+
+    // 문자열로 변환 (혹시 다른 타입일 경우 대비)
+    const stringValue = String(value);
+
+    // 정규식 체인을 적용하여 포맷팅
+    const formatted = stringValue
+        .replace(/[^0-9]/g, "") // 1. 숫자 외 문자 제거 (점(.) 제거됨)
+        .replace(
+            /^(\d{0,3})(\d{0,4})(\d{0,4})$/,
+            "$1-$2-$3"
+        ) // 2. 그룹 나누고 하이픈 추가
+        .replace(/(\-{1,2})$/, ""); // 3. 끝에 있는 하이픈 1~2개 제거
+
+    // 추가: '--'가 중간에 생기는 경우를 대비해 하나로 변경
+    return formatted.replace(/--/g, "-");
+};
+
+// 입력된 문자열을 대한민국 E.164 형식 (+82...)으로 변환합니다.
+export const formatPhoneNumberToE164 = (value) => {
+    if (!value) {
+        return "";
+    }
+
+    // 1. 숫자만 추출
+    const digits = String(value).replace(/[^0-9]/g, "");
+
+    // 2. 정규식을 사용하여 '01...' 형태를 '+821...' 형태로 변환
+    const e164 = digits.replace(
+        /^0(1[0-9]{8,9})$/,
+        "+82$1"
+    );
+
+    // 3. 변환 결과 확인
+    if (e164 === digits) {
+        // 이미 +82로 시작하는 유효한 형식인지 체크
+        if (/^\+821[0-9]{8,9}$/.test(digits)) {
+            return digits; // 이미 올바른 형식이면 그대로 반환
+        }
+        return ""; // 변환 대상이 아니면 빈 문자열 반환
+    } else {
+        return e164;
+    }
+};


### PR DESCRIPTION
## ID

-   ALT-3-3

## 변경 내용

- 사용자가 전화번호 입력 시 정해진 형식(예: 010-xxxx-xxxx)에 맞춰 자동으로 하이폰 삽입
- 사용자가 입력한 전화번호를 본인인증 요청 시 국제 표준 형식으로 변환하여 서버에 전송
- 본인인증 실패 또는 입력 오류 시 해당 입력 필드의 테두리를 강조, 하단에 에러 메시지 표시

## 구현 사항

- 정규 표현식을 사용하여 전화번호 input 컴포넌트에 자동 하이폰 사입 로직 구현
- 사용자가 입력한 전화번호를 본인인증 요청 전 E.164형식으로 변환
- 본인인증 응답에 따라 에러 상태를 관리하는 useState를 사용하여 조건부 렌더링되도록 구현

## 참고 이미지
<img width="447" alt="스크린샷 2025-04-29 오후 2 16 59" src="https://github.com/user-attachments/assets/d10e5198-78ed-46e6-88df-2df91d5e326a" />
