### PR TITLE
fix: 로그인 요청 body에 플랫폼 타입 추가

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -181,6 +181,7 @@ export const loginWithProvider = async (
                 body: JSON.stringify({
                     provider,
                     authorizationCode,
+                    platformType: 'WEB',
                 }),
             }
         );


### PR DESCRIPTION
## 변경 내용

-   소셜 로그인 API 요청 body에 플랫폼 타입 파라미터 추가

## 구현 사항

-   로그인 요청 JSON 구조 개선: 기존 provider, authorizationCode 외에 platformType: 'WEB' 필드를 추가하여 서버에서 클라이언트 환경을 명확히 구분할 수 있도록 구현